### PR TITLE
Make sure the healthcheck scripts are executable

### DIFF
--- a/mariadb/10.1.dockerfile
+++ b/mariadb/10.1.dockerfile
@@ -1,5 +1,6 @@
 FROM mariadb:10.1
 
-COPY ./docker-healthcheck /usr/bin/
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
 
 HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]

--- a/postgres/10.1.dockerfile
+++ b/postgres/10.1.dockerfile
@@ -1,5 +1,6 @@
 FROM postgres:10.1-alpine
 
-COPY ./docker-healthcheck /usr/bin/
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
 
 HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]

--- a/postgres/9.3.dockerfile
+++ b/postgres/9.3.dockerfile
@@ -1,5 +1,6 @@
 FROM postgres:9.3-alpine
 
-COPY ./docker-healthcheck /usr/bin/
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
 
 HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]

--- a/postgres/9.6.dockerfile
+++ b/postgres/9.6.dockerfile
@@ -1,5 +1,6 @@
 FROM postgres:9.6-alpine
 
-COPY ./docker-healthcheck /usr/bin/
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
 
 HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]


### PR DESCRIPTION
Additionally move the scripts to `/usr/loca/bin`, which is the same directory Docker uses on their images as well.