### PR TITLE
Postgres healthcheck default database name

### DIFF
--- a/postgres/docker-healthcheck
+++ b/postgres/docker-healthcheck
@@ -3,7 +3,7 @@ set -eo pipefail
 
 host="$(hostname -i || echo '127.0.0.1')"
 user="${POSTGRES_USER:-postgres}"
-db="${POSTGRES_DB:-$POSTGRES_USER}"
+db="${POSTGRES_DB:-$user}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-}"
 
 args=(


### PR DESCRIPTION
Cover default `db` naming case when `POSTGRES_USER` and `POSTGRES_DB` are not set.